### PR TITLE
Add support for certificate CA upload

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,9 @@ filebeat_config:
     to_syslog: true
     level: error
 
+filebeat_ca_path: /etc/filebeat/certificate_authorities.crt
+filebeat_ca_local_path:
+
 # The installation state of the filebeat package, passed to the appropriate
 # packaging module (yum/apt) as the 'state'.
 # Set to 'latest' to upgrade.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,15 @@
   notify:
     - restart filebeat
 
+- name: copy ca certificate if required
+  copy:
+    src: "{{ filebeat_ca_local_path }}"
+    dest: "{{ filebeat_ca_path }}"
+    owner: root
+    group: root
+    mode: 0400
+  when: filebeat_ca_local_path|default(None) != None
+
 - name: flush handlers to prevent start then restart
   meta: flush_handlers
 


### PR DESCRIPTION
Filebeat is used frequently to send events to a Logstash server with SSL encryption. In that case, Filebeat needs a certificate authority file to check the server certificate. I could have written a new role to copy the certificate, but I'm lazy as hell and I thought this role could do this as well.

A minimal example of use:

``` yaml

---
filebeat_ca_local_path: files/foo_ca_chain.crt

# A default is provided, but the user can choose to save the file to a different destination
# filebeat_ca_path: /etc/filebeat/foo_ca_chain.crt

filebeat_config:
  filebeat:
    (...)
  output:
    logstash:
      hosts: ["1.2.3.4:5044"]
      tls:
        certificate_authorities: ["{{ filebeat_ca_path }}"]
```

Feel free to accept or not this PR, as these changes could be out of the scope of this role.
