### PR TITLE
Ensure versions

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,11 +13,12 @@ provisioner:
     docker_opts: "--userland-proxy=false --bip=192.168.200.1/22"
 
 platforms:
-  - name: centos-6.7
-  - name: centos-7.1
+  - name: centos-6.8
+  - name: centos-7.2
     provisioner:
-      ansible_yum_repo: https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-7.noarch.rpm
+      ansible_yum_repo: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 suites:
   - name: default
   - name: cacert
+  - name: version5.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    artifactory (2.3.3)
+    artifactory (2.5.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     highline (1.7.8)
@@ -13,25 +13,29 @@ GEM
     librarian (0.1.2)
       highline
       thor (~> 0.15)
-    librarian-ansible (3.0.1)
+    librarian-ansible (3.0.2)
       faraday
       librarian (~> 0.1.0)
-    mixlib-install (1.1.0)
+    mixlib-install (2.1.5)
       artifactory
       mixlib-shellout
       mixlib-versioning
-    mixlib-shellout (2.2.6)
+      thor
+    mixlib-shellout (2.2.7)
     mixlib-versioning (1.1.0)
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
+    net-ssh-gateway (1.2.0)
+      net-ssh (>= 2.6.5)
     safe_yaml (1.0.4)
-    test-kitchen (1.10.2)
-      mixlib-install (~> 1.0, >= 1.0.4)
+    test-kitchen (1.13.2)
+      mixlib-install (>= 1.2, < 3.0)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
       net-ssh (>= 2.9, < 4.0)
+      net-ssh-gateway (~> 1.2.0)
       safe_yaml (~> 1.0)
       thor (~> 0.18)
     thor (0.19.1)
@@ -43,3 +47,6 @@ DEPENDENCIES
   kitchen-ansible (~> 0.0.17)
   kitchen-vagrant
   test-kitchen
+
+BUNDLED WITH
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Installs Elastic's Filebeat for forwarding logs.
 Role Variables
 --------------
 
+ - `filebeat_version` - The version of filebeat to install. Defaults to `1.3.1`.
  - `filebeat_config` - YAML representation of your filebeat config. This is templated directly into the configuration file as YAML. See the [example configuration](https://github.com/elastic/filebeat/blob/master/etc/filebeat.yml) for an exhaustive list of configuration options. Defaults to:
 
   ``` yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# The version of filebeat to install
+filebeat_version: 1.3.1
+
 # `filebeat_config` is templated directly into filebeat.yml for the config.
 # You are expected to override this variable, as these configurations are
 # only suited for development purposes.
@@ -27,9 +30,3 @@ filebeat_config:
 filebeat_ca_cert: null
 # Path to which the above certificate will be uploaded
 filebeat_ca_path: /etc/filebeat/ca.crt
-
-# The installation state of the filebeat package, passed to the appropriate
-# packaging module (yum/apt) as the 'state'.
-# Set to 'latest' to upgrade.
-filebeat_package_state: present
-filebeat_version: 1.3.1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,3 +32,4 @@ filebeat_ca_path: /etc/filebeat/ca.crt
 # packaging module (yum/apt) as the 'state'.
 # Set to 'latest' to upgrade.
 filebeat_package_state: present
+filebeat_version: 1.3.1

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,4 +1,12 @@
 ---
+- set_fact:
+    filebeat_apt_repo: "{{ filebeat_apt_repo_v1 }}"
+  when: filebeat_version < '5.0.0'
+
+- set_fact:
+    filebeat_apt_repo: "{{ filebeat_apt_repo_v5 }}"
+  when: filebeat_version >= '5.0.0'
+
 - name: add elastic gpg key
   apt_key:
     url: "{{ filebeat_gpg_url }}"
@@ -11,7 +19,7 @@
 
 - name: install filebeat
   apt:
-    name: filebeat
+    name: filebeat={{ filebeat_version }}
     state: "{{ filebeat_package_state }}"
   notify:
     - restart filebeat

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,12 +1,4 @@
 ---
-- set_fact:
-    filebeat_apt_repo: "{{ filebeat_apt_repo_v1 }}"
-  when: filebeat_version < '5.0.0'
-
-- set_fact:
-    filebeat_apt_repo: "{{ filebeat_apt_repo_v5 }}"
-  when: filebeat_version >= '5.0.0'
-
 - name: add elastic gpg key
   apt_key:
     url: "{{ filebeat_gpg_url }}"

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -12,6 +12,6 @@
 - name: install filebeat
   apt:
     name: filebeat={{ filebeat_version }}
-    state: "{{ filebeat_package_state }}"
+    state: present
   notify:
     - restart filebeat

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- include_vars: "{{ item }}"
-  with_first_found:
-    - "../vars/{{ ansible_os_family }}.yml"
-    - "../vars/default.yml"
-
 - include: redhat.yml
   when: ansible_os_family == 'RedHat'
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,12 +1,4 @@
 ---
-- set_fact:
-    filebeat_apt_repo: "{{ filebeat_repo_url_v1 }}"
-  when: filebeat_version < '5.0.0'
-
-- set_fact:
-    filebeat_apt_repo: "{{ filebeat_repo_url_v5 }}"
-  when: filebeat_version >= '5.0.0'
-
 - name: add rpm key for elastic.co
   rpm_key:
     key: "{{ filebeat_gpg_url }}"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -13,7 +13,7 @@
 
 - name: install filebeat
   yum:
-    name: filebeat
-    state: "{{ filebeat_package_state }}"
+    name: "filebeat-{{ filebeat_version }}"
+    state: present
   notify:
     - restart filebeat

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,4 +1,12 @@
 ---
+- set_fact:
+    filebeat_apt_repo: "{{ filebeat_repo_url_v1 }}"
+  when: filebeat_version < '5.0.0'
+
+- set_fact:
+    filebeat_apt_repo: "{{ filebeat_repo_url_v5 }}"
+  when: filebeat_version >= '5.0.0'
+
 - name: add rpm key for elastic.co
   rpm_key:
     key: "{{ filebeat_gpg_url }}"

--- a/test/integration/version5.0/bats/default.bats
+++ b/test/integration/version5.0/bats/default.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+@test "filebeat script is in path" {
+    command -v filebeat.sh
+}
+
+@test "/tmp/filebeat is in filebeat.yml config" {
+    grep "file: {filename: filebeat, path: /tmp/filebeat}" /etc/filebeat/filebeat.yml
+}
+
+@test "filebeat is running" {
+    service filebeat status
+}
+
+@test "ca certificate does not exist" {
+    [ ! -f /etc/filebeat/ca.crt ]
+}

--- a/test/integration/version5.0/default.yml
+++ b/test/integration/version5.0/default.yml
@@ -1,0 +1,7 @@
+- name: test filebeat 5.0.0 install
+  hosts: all
+  sudo: yes
+  vars:
+    filebeat_version: 5.0.0
+  roles:
+    - ansible-filebeat

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,1 +1,0 @@
-filebeat_apt_repo: "deb https://packages.elastic.co/beats/apt stable main"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,2 +1,0 @@
----
-filebeat_repo_url: https://packages.elastic.co/beats/yum/el/$basearch

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,12 @@
 ---
 filebeat_gpg_url: https://packages.elastic.co/GPG-KEY-elasticsearch
-filebeat_apt_repo_v5: "deb https://artifacts.elastic.co/packages/5.x/apt stable main"
+
+# Debian
 filebeat_apt_repo_v1: "deb https://packages.elastic.co/beats/apt stable main"
+filebeat_apt_repo_v5: "deb https://artifacts.elastic.co/packages/5.x/apt stable main"
+filebeat_apt_repo: "{{ filebeat_version|version_compare('5', '<')|ternary(filebeat_apt_repo_v1, filebeat_apt_repo_v5) }}"
+
+# Redhat
 filebeat_repo_url_v1: https://packages.elastic.co/beats/yum/el/$basearch
 filebeat_repo_url_v5: https://artifacts.elastic.co/packages/5.x/yum
+filebeat_repo_url: "{{ filebeat_version|version_compare('5', '<')|ternary(filebeat_repo_url_v1, filebeat_repo_url_v5) }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,6 @@
 ---
 filebeat_gpg_url: https://packages.elastic.co/GPG-KEY-elasticsearch
+filebeat_apt_repo_v5: "deb https://artifacts.elastic.co/packages/5.x/apt stable main"
+filebeat_apt_repo_v1: "deb https://packages.elastic.co/beats/apt stable main"
+filebeat_repo_url_v1: https://packages.elastic.co/beats/yum/el/$basearch
+filebeat_repo_url_v5: https://artifacts.elastic.co/packages/5.x/yum


### PR DESCRIPTION
- role vars are automatically included when vars/main.yml are present, therefore no need to have an include task
- defined repos for v1 and v5 versions of filebeat per os_version
- add conditionals to define repos based on the filebeat_version var