### PR TITLE
Adjust role for buliding AMIs with Packer

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,3 +47,6 @@ filebeat_apt_repo: "{{ filebeat_version|version_compare('5', '<')|ternary(filebe
 filebeat_repo_url_v1: https://packages.elastic.co/beats/yum/el/$basearch
 filebeat_repo_url_v5: https://artifacts.elastic.co/packages/5.x/yum
 filebeat_repo_url: "{{ filebeat_version|version_compare('5', '<')|ternary(filebeat_repo_url_v1, filebeat_repo_url_v5) }}"
+
+# Set to false for AMI building with packer
+start_services: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,4 @@
   service:
     name: filebeat
     state: restarted
+  when: start_services

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,9 +42,14 @@
 - name: flush handlers to prevent start then restart
   meta: flush_handlers
 
-- name: start and enable filebeat
+- name: enable filebeat
+  service:
+    name: filebeat
+    enabled: true
+    daemon_reload: true
+
+- name: start filebeat
   service:
     name: filebeat
     state: started
-    enabled: true
   when: start_services

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- import_tasks: redhat.yml
+- include: redhat.yml
   when: ansible_os_family == 'RedHat'
 
-- import_tasks: debian.yml
+- include: debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: create filebeat.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,11 +42,18 @@
 - name: flush handlers to prevent start then restart
   meta: flush_handlers
 
-- name: enable filebeat
-  service:
+- name: enable filebeat (systemd)
+  systemd:
     name: filebeat
     enabled: true
     daemon_reload: true
+  when: ansible_service_mgr == "systemd"
+
+- name: enable filebeat (other init)
+  service:
+    name: filebeat
+    enabled: true
+  when: ansible_service_mgr != "systemd"
 
 - name: start filebeat
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,9 +42,14 @@
 - name: flush handlers to prevent start then restart
   meta: flush_handlers
 
+- name: check if systemd present
+  stat:
+    path: /bin/systemctl
+  register: stat_result
+
 - name: reload systemd daemon
   shell: "systemctl daemon-reload"
-  when: ansible_service_mgr == "systemd"
+  when: stat_result.stat.exists == true
 
 - name: enable filebeat
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
-- include: redhat.yml
+- import_tasks: redhat.yml
   when: ansible_os_family == 'RedHat'
 
-- include: debian.yml
+- import_tasks: debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: create filebeat.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,18 +42,14 @@
 - name: flush handlers to prevent start then restart
   meta: flush_handlers
 
-- name: enable filebeat (systemd)
-  systemd:
-    name: filebeat
-    enabled: true
-    daemon_reload: true
+- name: reload systemd daemon
+  shell: "systemctl daemon-reload"
   when: ansible_service_mgr == "systemd"
 
-- name: enable filebeat (other init)
+- name: enable filebeat
   service:
     name: filebeat
     enabled: true
-  when: ansible_service_mgr != "systemd"
 
 - name: start filebeat
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,3 +47,4 @@
     name: filebeat
     state: started
     enabled: true
+  when: start_services

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -17,3 +17,12 @@
     state: present
   notify:
     - restart filebeat
+
+- name: modify filebeat service file to include environment variables
+  lineinfile:
+    path: /usr/lib/systemd/system/filebeat.service
+    regexp: '^EnvironmentFile=/etc/sysconfig/filebeat$'
+    line: "EnvironmentFile=/etc/sysconfig/filebeat"
+    insertafter: '^\[Service\]$'
+  notify:
+    - restart filebeat


### PR DESCRIPTION
Hi, 

I've added a little switch I use often in Ansible for building AMI packages in AWS using Packer tool.
The thing is that while building we don't want to start the services, because they are often in unconfigured state, so setting start_services to false prevents that.

The default behaviour is unchanged, so running playbook with this role installs _and starts_ filebeat.

The other thing I've added (only for RedHat, as I know how to do it in RH) is the environment file reference for systemd file - this is to be used in templates, where you can use env variables for dynamic configuration of filebeat.

Best regards

Łukasz Tomaszkiewicz