### PR TITLE
Support for 6.x versions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # The version of filebeat to install
-filebeat_version: 1.3.1
+filebeat_version: 6.1.1
 
 # `filebeat_config` is templated directly into filebeat.yml for the config.
 # You are expected to override this variable, as these configurations are
@@ -41,9 +41,9 @@ filebeat_ssl_key_path: /etc/filebeat/ssl.key
 filebeat_gpg_url: https://packages.elastic.co/GPG-KEY-elasticsearch
 ## Debian
 filebeat_apt_repo_v1: "deb https://packages.elastic.co/beats/apt stable main"
-filebeat_apt_repo_v5: "deb https://artifacts.elastic.co/packages/5.x/apt stable main"
+filebeat_apt_repo_v5: "deb https://artifacts.elastic.co/packages/{{ filebeat_version.split('.')[0] }}.x/apt stable main"
 filebeat_apt_repo: "{{ filebeat_version|version_compare('5', '<')|ternary(filebeat_apt_repo_v1, filebeat_apt_repo_v5) }}"
 ## Redhat
 filebeat_repo_url_v1: https://packages.elastic.co/beats/yum/el/$basearch
-filebeat_repo_url_v5: https://artifacts.elastic.co/packages/5.x/yum
+filebeat_repo_url_v5: https://artifacts.elastic.co/packages/{{ filebeat_version.split('.')[0] }}.x/yum
 filebeat_repo_url: "{{ filebeat_version|version_compare('5', '<')|ternary(filebeat_repo_url_v1, filebeat_repo_url_v5) }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,8 +42,8 @@ filebeat_gpg_url: https://packages.elastic.co/GPG-KEY-elasticsearch
 ## Debian
 filebeat_apt_repo_v1: "deb https://packages.elastic.co/beats/apt stable main"
 filebeat_apt_repo_v5: "deb https://artifacts.elastic.co/packages/{{ filebeat_version.split('.')[0] }}.x/apt stable main"
-filebeat_apt_repo: "{{ filebeat_version|version_compare('5', '<')|ternary(filebeat_apt_repo_v1, filebeat_apt_repo_v5) }}"
+filebeat_apt_repo: "{{ filebeat_version is version_compare('5', '<')|ternary(filebeat_apt_repo_v1, filebeat_apt_repo_v5) }}"
 ## Redhat
 filebeat_repo_url_v1: https://packages.elastic.co/beats/yum/el/$basearch
 filebeat_repo_url_v5: https://artifacts.elastic.co/packages/{{ filebeat_version.split('.')[0] }}.x/yum
-filebeat_repo_url: "{{ filebeat_version|version_compare('5', '<')|ternary(filebeat_repo_url_v1, filebeat_repo_url_v5) }}"
+filebeat_repo_url: "{{ filebeat_version is version_compare('5', '<')|ternary(filebeat_repo_url_v1, filebeat_repo_url_v5) }}"


### PR DESCRIPTION
Forgot to open this a while ago. Not sure if this is still maintained. But we're using this on our local fork to support 6.x. Also bumps the default version to a more recent.